### PR TITLE
bump evaluate to `0.3.0`

### DIFF
--- a/asr_requirements.txt
+++ b/asr_requirements.txt
@@ -10,7 +10,7 @@ Command==0.1.0
 datasets==2.5.1
 dill==0.3.5.1
 docker-pycreds==0.4.0
-evaluate==0.2.2
+evaluate==0.3.0
 exceptiongroup==1.0.0rc9
 filelock==3.8.0
 frozenlist==1.3.1


### PR DESCRIPTION
There is an issue with `evaluate` before 0.3.0 concerning the Hugging Face hub integration. I suggest upgrading to `0.3.0` which should not have any breaking changes and be functionally equivalent since this version might break in a few months.